### PR TITLE
GO-7383 Make export diagnostics traceable and reduce routine warnings

### DIFF
--- a/bundle/README.md
+++ b/bundle/README.md
@@ -26,8 +26,28 @@ from the snapshots being exported. Use the same mappings for `BuildPlan`,
 would give a type document and references to it different ids. Types whose
 ids already have the derived form need no extra mapping.
 
+`TypeIdentityMismatchError` preserves the affected type id through export
+wrappers. Report it as `type_identity_mismatch` with translated user-facing
+copy, keeping its error text for technical diagnostics.
+
+`IssueOptionDescriptionOmitted` identifies a non-blocking format limitation:
+the option exports, but its description is not carried in the dictionary.
+Unused property keys are also informational. Other omitted reconstruction
+issues can indicate lost content and must not be downgraded wholesale.
+`IssueOptionContentOmitted` is a warning for extra details or page blocks on
+relation options that their dictionary entries cannot carry. This downgrade
+applies only to relation options; property and other object omissions keep
+their existing severity. An option missing its name or owning property still
+raises `IssueOmittedReconstruction`.
+
 View ids remain intact even with `CompactBlockLabels` or `OmitIds`, so
 `index.widgets[].view_id` still selects the same view after import.
+
+Heart's snapshot export collection includes both chat kinds: `chat`
+(`ChatDerivedObject`) and the legacy `chat_object`. Their object metadata and
+internal keys travel with the bundle, so homepage and widget references can
+resolve to them. Chat message history lives in the CRDT store outside object
+snapshots and is not included; imported chats are empty (SPEC §2).
 
 To export files without embedding their bytes, preserve their remote access
 metadata and identify the source network:
@@ -59,3 +79,44 @@ that is missing. This package validates the metadata and references; the
 application's file service retrieves bytes on the identified network.
 See [SPEC §2h](../format/v2/SPEC.md#2h-remote-file-metadata-file_remote) and
 the [remote file example](../format/v2/examples/remote_file/).
+
+## Export notes
+
+`Stats.UnusedPropertyKeys` retains the complete inventory of unused property
+definitions omitted from the dictionary. Heart suppresses `unused_property`
+notes for keys in its built-in property registry: these omissions are routine
+and the application already supplies their definitions. Unused custom property
+definitions still produce informational notes. Other diagnostics for built-in
+properties, including unresolved references, remain visible.
+
+## Unresolved reference diagnostics
+
+`Stats.UnresolvedReferences` retains each unresolved index location, including
+the source `ObjectID` and `SourcePath` when lifted from a snapshot. `Path`
+identifies the index field, such as `/homepage` or
+`/widgets/2/target`; `TargetObjectID` identifies the missing destination.
+Repeated targets at different locations remain separate diagnostics.
+`Stats.UnresolvedTargets` and the index's unresolved-target list remain unique
+target inventories. Authored index fields without a source snapshot have a
+path and target but no source object.
+
+Codec `unresolved_target` warnings put the complete source location in `Path`,
+for example `/blocks/<stored-block-id>/object_id`,
+`/blocks/<stored-block-id>/text/marks/0/param`, or `/properties/<stored-key>/1`.
+Block IDs and property keys use JSON Pointer escaping; list positions refer to
+the original snapshot. These are source locations, not array pointers into the
+exported document. The export caller prefixes the owning object ID to produce
+a self-contained report path, such as `<object-id>/blocks/<block-id>/object_id`
+or `<object-id>/properties/<stored-key>/1`; the message names the missing target.
+Index references with a known source use the same object prefix and `SourcePath`
+in the report; otherwise they use `index.json#` followed by the index pointer.
+
+## Known integration issue: icons in 1-to-1 spaces
+
+In 1-to-1 spaces, `spaceIcon` can reference a raw file CID with no corresponding
+file object in the space's object store. Export preserves that CID in
+`index.json` at `/icon/file`, but the bundle's target check expects an exported
+object and reports `unresolved_target`. This is a known mismatch between the
+stored icon reference and the bundle's object-reference model; it does not by
+itself mean an object was deleted or a file export failed. Resolving these raw
+icon CIDs is not yet implemented.

--- a/bundle/compose.go
+++ b/bundle/compose.go
@@ -56,6 +56,15 @@ type IssueCategory string
 // inference rather than a stored document.
 const IssueOmittedReconstruction IssueCategory = "omitted_reconstruction"
 
+// IssueOptionDescriptionOmitted is a non-blocking format limitation: the option
+// travels in the dictionary, but its description has no dictionary field.
+const IssueOptionDescriptionOmitted IssueCategory = "option_description_omitted"
+
+// IssueOptionContentOmitted means an exported option has additional details or
+// page blocks that its dictionary entry cannot carry. Report it as a warning;
+// failures to carry the option itself remain omitted reconstruction errors.
+const IssueOptionContentOmitted IssueCategory = "option_content_omitted"
+
 // Stats is what Finish can say about the composed bundle, for summaries.
 type Stats struct {
 	// DictionaryUninstalled counts the entries carrying `uninstalled` —
@@ -128,6 +137,8 @@ type Stats struct {
 	// its normal state. The slots are the ones bundle.Validate refuses on,
 	// so an export states exactly what a later validation would find.
 	UnresolvedTargets []string
+	// UnresolvedReferences retains each missing index target with source location.
+	UnresolvedReferences []anyblockjson.ObjectReference
 	// RefusedOptions names the vocabularies the dictionary cannot state and
 	// why — one `key: reason` line each, sorted. The writer refuses a
 	// vocabulary on a property whose format does not admit one (§2a), and
@@ -233,7 +244,8 @@ type Composer struct {
 	// function Marshal used to write them, rather than a second opinion that
 	// could disagree about a type's derived id. They answer the one question
 	// no document can: whether an id this index names is carried here.
-	documentIds map[string]bool
+	documentIds           map[string]bool
+	indexReferenceSources map[anyblockjson.ObjectReference]struct{}
 
 	written int
 	omitted int
@@ -331,6 +343,7 @@ func (c *Composer) observe(sbType model.SmartBlockType, base *model.SmartBlockSn
 	// runs BEFORE the omission is recorded, so a bundle can never drop the
 	// document without having written what it carried.
 	if anyblockjson.OmittedSpaceSettings(sbType, base) {
+		c.recordIndexReferenceSources(sbType, base)
 		c.observedSpaceSettings = true
 		var observed anyblockjson.Index
 		anyblockjson.IndexFromSpaceSettings(&observed, base)
@@ -367,6 +380,7 @@ func (c *Composer) observe(sbType model.SmartBlockType, base *model.SmartBlockSn
 	// apart silently. A nil snapshot means the index carries no sidebar
 	// state because the object held none — the predicate is the proof.
 	if anyblockjson.OmittedWidgetObject(sbType, base) {
+		c.recordIndexReferenceSources(sbType, base)
 		anyblockjson.IndexFromWidgetObject(&c.index, base)
 		rebuilt, err := anyblockjson.WidgetsSnapshot(&c.index)
 		if err != nil {
@@ -641,7 +655,11 @@ func (c *Composer) observeRelationOption(base *model.SmartBlockSnapshotBase) []I
 		// the option is omitted anyway — a kept one would need a home, and
 		// giving it one puts `options/` back in the layout — but what the
 		// entry cannot carry is named rather than dropped in silence (§1.7)
-		issues = append(issues, Issue{Category: IssueOmittedReconstruction,
+		category := IssueOptionContentOmitted
+		if len(extra) == 1 && extra[0] == "description" {
+			category = IssueOptionDescriptionOmitted
+		}
+		issues = append(issues, Issue{Category: category,
 			Detail: fmt.Sprintf("relation option %q of property %q carries %s, which its dictionary entry does not state",
 				ident.id, key, strings.Join(extra, ", "))})
 	}
@@ -1095,6 +1113,7 @@ func (c *Composer) Finish() (index, properties []byte, stats Stats, err error) {
 	}
 	stats.RefusedOptions = refusedOptions
 	stats.UnresolvedTargets = unresolvedTargets
+	stats.UnresolvedReferences = c.unresolvedIndexReferences(&idx)
 	return idxData, dictData, stats, nil
 }
 
@@ -1498,5 +1517,47 @@ func copyNonEmpty(m map[string]string) map[string]string {
 	for k, v := range m {
 		out[k] = v
 	}
+	return out
+}
+
+func (c *Composer) recordIndexReferenceSources(sbType model.SmartBlockType, base *model.SmartBlockSnapshotBase) {
+	if c.indexReferenceSources == nil {
+		c.indexReferenceSources = map[anyblockjson.ObjectReference]struct{}{}
+	}
+	for _, ref := range anyblockjson.IndexReferencesFromSnapshot(sbType, base, c.opts) {
+		c.indexReferenceSources[ref] = struct{}{}
+	}
+}
+
+func (c *Composer) unresolvedIndexReferences(idx *anyblockjson.Index) []anyblockjson.ObjectReference {
+	var out []anyblockjson.ObjectReference
+	for _, ref := range idx.ObjectReferences(c.opts) {
+		if c.documentIds[ref.TargetObjectID] {
+			continue
+		}
+		found := false
+		for source := range c.indexReferenceSources {
+			if source.Path == ref.Path && source.TargetObjectID == ref.TargetObjectID {
+				out = append(out, source)
+				found = true
+			}
+		}
+		if !found {
+			out = append(out, ref)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if a.TargetObjectID != b.TargetObjectID {
+			return a.TargetObjectID < b.TargetObjectID
+		}
+		if a.Path != b.Path {
+			return a.Path < b.Path
+		}
+		if a.ObjectID != b.ObjectID {
+			return a.ObjectID < b.ObjectID
+		}
+		return a.SourcePath < b.SourcePath
+	})
 	return out
 }

--- a/bundle/composeoptionapikey_test.go
+++ b/bundle/composeoptionapikey_test.go
@@ -65,3 +65,32 @@ func TestComposerCarriesAnOptionsApiKey(t *testing.T) {
 		"a stored api key does not follow a rename, so nothing downstream can rebuild it")
 	assert.Empty(t, byName["Done"].ApiKey, "an option the store holds none for states none")
 }
+
+func TestOptionDescriptionNoteDoesNotHideOtherOmissions(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		content  bool
+		category IssueCategory
+	}{
+		{"description only", false, IssueOptionDescriptionOmitted},
+		{"description and page content", true, IssueOptionContentOmitted},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newComposer(t, anyblockjson.Options{}, "Synthetic")
+			option := optionSnapshot("option-test", "tag", "Test option", "red", "test-option")
+			option.Details.Fields["description"] = strVal("An optional description")
+			if tc.content {
+				option.Blocks = append(option.Blocks, &model.Block{Id: "note", Content: &model.BlockContentOfText{Text: &model.BlockContentText{Text: "Keep this content"}}})
+			}
+			omitted, issues := c.Observe(model.SmartBlockType_STRelationOption, option)
+			require.True(t, omitted)
+			require.Len(t, issues, 1)
+			assert.Equal(t, tc.category, issues[0].Category)
+			require.NoError(t, c.ObserveWritten(model.SmartBlockType_Page, &model.SmartBlockSnapshotBase{}, []byte(`{"formatVersion":"2.0","properties":{"tag":["Test option"]}}`)))
+			_, dictionary, stats, err := c.Finish()
+			require.NoError(t, err)
+			assert.Equal(t, 1, stats.OptionsLifted)
+			assert.Contains(t, string(dictionary), "Test option")
+		})
+	}
+}

--- a/bundle/composeunresolved_test.go
+++ b/bundle/composeunresolved_test.go
@@ -161,3 +161,45 @@ func (composerTypeVocabulary) TypeIdByKey(key string) (string, bool) {
 	}
 	return "", false
 }
+
+func TestUnresolvedIndexReferencesRetainSnapshotSources(t *testing.T) {
+	c := newComposer(t, anyblockjson.Options{}, "Synthetic")
+	space := testSpaceSnapshot()
+	space.Details.Fields["id"] = strVal("space-source")
+	space.Details.Fields["homepage"] = strVal(testfixtures.ObjectID)
+	space.Details.Fields["iconImage"] = strVal(testfixtures.ObjectID)
+	omitted, issues := c.Observe(model.SmartBlockType_Workspace, space)
+	require.True(t, omitted)
+	require.Empty(t, issues)
+	widgets, err := anyblockjson.WidgetsSnapshot(&anyblockjson.Index{Widgets: []anyblockjson.Widget{{Target: testfixtures.ObjectID}, {Target: testfixtures.ObjectIDAlt}}})
+	require.NoError(t, err)
+	widgets.Details.Fields["id"] = strVal("widget-source")
+	var linkIDs []string
+	for _, b := range widgets.Blocks {
+		if b.GetLink() != nil {
+			b.GetLink().TargetBlockId = testfixtures.ObjectID
+			linkIDs = append(linkIDs, b.Id)
+		}
+	}
+	require.Len(t, linkIDs, 2)
+	omitted, issues = c.Observe(model.SmartBlockType_Widget, widgets)
+	require.True(t, omitted)
+	require.Empty(t, issues)
+	// A repeat must not duplicate the same source occurrence.
+	_, _ = c.Observe(model.SmartBlockType_Workspace, space)
+	_, _, stats, err := c.Finish()
+	require.NoError(t, err)
+	assert.Equal(t, []string{testfixtures.ObjectID}, stats.UnresolvedTargets)
+	require.Len(t, stats.UnresolvedReferences, 4)
+	assert.Equal(t, anyblockjson.ObjectReference{ObjectID: "space-source", SourcePath: "/properties/homepage", TargetObjectID: testfixtures.ObjectID, Path: "/homepage"}, stats.UnresolvedReferences[0])
+	assert.Equal(t, anyblockjson.ObjectReference{ObjectID: "space-source", SourcePath: "/properties/iconImage", TargetObjectID: testfixtures.ObjectID, Path: "/icon/file"}, stats.UnresolvedReferences[1])
+	var reportedBlocks []string
+	for _, ref := range stats.UnresolvedReferences[2:] {
+		assert.Equal(t, "widget-source", ref.ObjectID)
+		assert.Equal(t, testfixtures.ObjectID, ref.TargetObjectID)
+		reportedBlocks = append(reportedBlocks, ref.SourcePath)
+	}
+	assert.ElementsMatch(t, []string{"/blocks/" + linkIDs[0] + "/object_id", "/blocks/" + linkIDs[1] + "/object_id"}, reportedBlocks)
+	assert.Equal(t, "/widgets/0/target", stats.UnresolvedReferences[2].Path)
+	assert.Equal(t, "/widgets/1/target", stats.UnresolvedReferences[3].Path)
+}

--- a/bundle/exportreferences_test.go
+++ b/bundle/exportreferences_test.go
@@ -29,7 +29,16 @@ func TestBuildPlanRequiresTypeReferenceMappings(t *testing.T) {
 			plan, err := BuildPlan(opts, docs)
 			require.Error(t, err, "unsafe mappings must be refused before paths are committed")
 			assert.Nil(t, plan)
-			assert.ErrorContains(t, err, "typeid-wine")
+			var mismatch *anyblockjson.TypeIdentityMismatchError
+			require.ErrorAs(t, err, &mismatch)
+			assert.Equal(t, "typeid-wine", mismatch.ObjectID)
+			assert.Equal(t, "wine", mismatch.InternalKey)
+			assert.Equal(t, "type-wine", mismatch.DocumentID)
+			if tc.keys["typeid-wine"] == "page" {
+				assert.Equal(t, "type-page", mismatch.ReferenceID)
+			} else {
+				assert.Equal(t, "typeid-wine", mismatch.ReferenceID)
+			}
 		})
 	}
 	plan, err := BuildPlan(anyblockjson.Options{ResolveProperties: planTypeResolver{
@@ -54,6 +63,9 @@ func TestComposerRequiresTheSameTypeMappingAsTheDocumentExporter(t *testing.T) {
 		c := newComposer(t, anyblockjson.Options{ResolveProperties: planTypeResolver{keyById: keys}}, "Wine")
 		err := c.ObserveWritten(model.SmartBlockType_STType, snapshot, data)
 		require.ErrorContains(t, err, "TypeResolver")
+		var mismatch *anyblockjson.TypeIdentityMismatchError
+		require.ErrorAs(t, err, &mismatch)
+		assert.Equal(t, "typeid-wine", mismatch.ObjectID)
 	}
 	c := newComposer(t, opts, "Wine")
 	require.NoError(t, c.ObserveWritten(model.SmartBlockType_STType, snapshot, data))

--- a/codec/anyblockjson/dataview.go
+++ b/codec/anyblockjson/dataview.go
@@ -31,7 +31,7 @@ func (e *exporter) dataviewToJSON(m *omap, dv *model.BlockContentDataview) error
 	target, isCollection, source := e.dataviewSourceForExport(dv)
 	// a singular reference slot: a target the space does not hold is
 	// written as the sentinel, never as if it existed (§9)
-	m.setNonEmpty("object_id", e.singularObjectRef("/blocks", "dataview object_id", target))
+	m.setNonEmpty("object_id", e.singularObjectRef("/blocks/object_id", "dataview object_id", target))
 	m.setNonEmpty("is_collection", isCollection)
 	m.setNonEmpty("source", stringsToAny(source))
 

--- a/codec/anyblockjson/derivedids_test.go
+++ b/codec/anyblockjson/derivedids_test.go
@@ -482,6 +482,9 @@ func TestDerivedIds_TypeDocumentIdComesFromItsOwnKey(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			data, err := Marshal(model.SmartBlockType_STType, typeDoc(), opts)
 			require.ErrorContains(t, err, "TypeResolver")
+			var mismatch *TypeIdentityMismatchError
+			require.ErrorAs(t, err, &mismatch)
+			assert.Equal(t, &TypeIdentityMismatchError{ObjectID: "typeid-corpse", InternalKey: "corpse", DocumentID: "type-corpse", ReferenceID: "typeid-corpse"}, mismatch)
 			assert.Nil(t, data, "missing reference mappings must not produce a disconnected type document")
 			assert.Equal(t, "type-corpse", FoldDocumentId(opts, model.SmartBlockType_STType, "typeid-corpse", "corpse"))
 

--- a/codec/anyblockjson/export.go
+++ b/codec/anyblockjson/export.go
@@ -338,12 +338,13 @@ func Marshal(sbType model.SmartBlockType, snapshot *model.SmartBlockSnapshotBase
 }
 
 type exporter struct {
-	opts     Options
-	snapshot *model.SmartBlockSnapshotBase
-	sbType   model.SmartBlockType
-	blocks   map[string]*model.Block
-	rootId   string
-	visited  map[string]bool // emitted block ids: breaks ChildrenIds cycles, dedupes shared children
+	warningBlockID string
+	opts           Options
+	snapshot       *model.SmartBlockSnapshotBase
+	sbType         model.SmartBlockType
+	blocks         map[string]*model.Block
+	rootId         string
+	visited        map[string]bool // emitted block ids: breaks ChildrenIds cycles, dedupes shared children
 	// fragmentRoot says rootId itself is the addressed fragment block. Whole
 	// documents instead start at the smartblock root's children.
 	fragmentRoot bool
@@ -2215,8 +2216,8 @@ func (e *exporter) propertyValue(key, servedKey string, v *types.Value) any {
 		// dropping dangling entries must not erase the fact that the
 		// property was set.
 		var out []any
-		for _, id := range valueStringList(v) {
-			if e.droppedMissingListEntry("/properties/"+servedKey, id) {
+		for n, id := range valueStringList(v) {
+			if e.droppedMissingListEntry(fmt.Sprintf("/properties/%s/%d", escapeSourcePathKey(key), n), id) {
 				continue
 			}
 			out = append(out, e.objectRef(id))
@@ -2419,6 +2420,9 @@ func (e *exporter) localId(id string) string {
 // first per the §4 canonical key order). The returned bool reports whether
 // the caller should descend into the block's children.
 func (e *exporter) blockToJSON(b *model.Block, depth int) (*omap, bool, error) {
+	previous := e.warningBlockID
+	e.warningBlockID = b.Id
+	defer func() { e.warningBlockID = previous }()
 	// a snapshot's block graph is untrusted: without this, a ChildrenIds
 	// cycle recurses to an unrecoverable stack overflow, and a block shared
 	// by two parents is emitted twice (duplicate ids fail validation)
@@ -2468,12 +2472,12 @@ func (e *exporter) blockToJSON(b *model.Block, depth int) (*omap, bool, error) {
 		m.setNonEmpty("url", bm.Url)
 		// a singular reference slot: a target the space does not hold is
 		// written as the sentinel, never as if it existed (§9)
-		m.setNonEmpty("object_id", e.singularObjectRef("/blocks", "bookmark object_id", bm.TargetObjectId))
+		m.setNonEmpty("object_id", e.singularObjectRef("/blocks/object_id", "bookmark object_id", bm.TargetObjectId))
 		withChildren = false
 	case *model.BlockContentOfLink:
 		l := orEmpty(c.Link)
 		m.set("type", "link")
-		m.setNonEmpty("object_id", e.singularObjectRef("/blocks", "link object_id", l.TargetBlockId))
+		m.setNonEmpty("object_id", e.singularObjectRef("/blocks/object_id", "link object_id", l.TargetBlockId))
 		if l.CardStyle != model.BlockContentLink_Text {
 			m.setNonEmpty("card_style", cardStyleNames.name(l.CardStyle))
 		}
@@ -2706,7 +2710,7 @@ func (e *exporter) fileToJSON(m *omap, f *model.BlockContentFile) {
 	// as the sentinel, never as if it existed (§9) — the legacy hash arm
 	// included, because in the un-migrated spaces that still store one the
 	// hash IS the file object's index row id
-	m.setNonEmpty("object_id", e.singularObjectRef("/blocks", typ+" object_id", objectId))
+	m.setNonEmpty("object_id", e.singularObjectRef("/blocks/object_id", typ+" object_id", objectId))
 	m.setNonEmpty("name", f.Name)
 	m.setNonEmpty("mime_type", f.Mime)
 	m.setNonEmpty("size", f.Size_)

--- a/codec/anyblockjson/iconcover.go
+++ b/codec/anyblockjson/iconcover.go
@@ -331,8 +331,6 @@ func iconOf(detail func(string) *types.Value, warn func(path, format string, arg
 			// supplies it is not choosing an icon.
 			if emoji := detail(detailKeyIconEmoji).GetStringValue(); emoji != "" {
 				ic.Emoji = emoji
-				warn("/icon", "this object holds both a named icon (%q) and an emoji (%q); "+
-					"the name wins and the emoji is carried as output-only baggage", name, emoji)
 			}
 			return ic
 		}

--- a/codec/anyblockjson/iconcover_test.go
+++ b/codec/anyblockjson/iconcover_test.go
@@ -266,16 +266,13 @@ func TestExport_AValueTheFormatCannotWriteIsDropped(t *testing.T) {
 	})
 }
 
-// The conflict carry-over is the only emitted shape with two icon sources, and
-// it is warned about rather than silent — 200 corpus objects, every one a
-// bundled type mid-migration from an emoji to a named icon.
-func TestExport_TheConflictCarryOverIsWarned(t *testing.T) {
+// Both icon sources survive export, so this migration state needs no warning.
+func TestExport_TheConflictCarryOverIsPreservedWithoutWarning(t *testing.T) {
 	icon, _, _, warnings := exportedIconCover(t, map[string]*types.Value{
 		"iconName": str("extension-puzzle"), "iconEmoji": str("🥚"), "iconOption": num(6)})
 	assert.Equal(t, `{"format":"icon","name":"extension-puzzle","color":"purple","emoji":"🥚"}`,
 		compactJSON(t, icon))
-	require.Len(t, warnings, 1)
-	assert.Contains(t, warnings[0].Message, "the name wins")
+	assert.Empty(t, warnings, "both stored icon values are preserved")
 }
 
 // Every emitted shape inverts to exactly the details that produced it, which

--- a/codec/anyblockjson/index.go
+++ b/codec/anyblockjson/index.go
@@ -496,6 +496,15 @@ func (i *Index) EffectiveEntryPoint() string {
 	return ""
 }
 
+// ObjectReference identifies one index reference and its original source when
+// the index was lifted from a stored snapshot. Path is a JSON pointer in index.json.
+type ObjectReference struct {
+	TargetObjectID string
+	ObjectID       string
+	SourcePath     string // location in the original object, when lifted
+	Path           string
+}
+
 // ReferencedObjectIds returns every OBJECT this index names, sorted and
 // without repeats, in the spelling MarshalIndex writes — the derived-id fold
 // included (§9), which is why it takes the same opts. These are the ids a
@@ -519,29 +528,35 @@ func (i *Index) EffectiveEntryPoint() string {
 // write time — ask one list of slots rather than each keeping its own. A
 // second list is how a slot gets checked in one place and not the other.
 func (i *Index) ReferencedObjectIds(opts Options) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, ref := range i.ObjectReferences(opts) {
+		if !seen[ref.TargetObjectID] {
+			seen[ref.TargetObjectID] = true
+			out = append(out, ref.TargetObjectID)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ObjectReferences keeps repeated targets at different locations distinct.
+func (i *Index) ObjectReferences(opts Options) []ObjectReference {
 	if i == nil {
 		return nil
 	}
-	seen := map[string]bool{}
-	var out []string
-	add := func(id string) {
-		if id == "" || IsPlatformId(id) {
-			return
+	var out []ObjectReference
+	add := func(path, id string) {
+		if id != "" && !IsPlatformId(id) {
+			out = append(out, ObjectReference{TargetObjectID: opts.foldRef(id), Path: path})
 		}
-		ref := opts.foldRef(id)
-		if seen[ref] {
-			return
-		}
-		seen[ref] = true
-		out = append(out, ref)
 	}
-	add(i.Entrypoint)
-	add(i.Homepage)
-	for _, w := range i.Widgets {
-		add(w.Target)
+	add("/entrypoint", i.Entrypoint)
+	add("/homepage", i.Homepage)
+	for n, w := range i.Widgets {
+		add(fmt.Sprintf("/widgets/%d/target", n), w.Target)
 	}
-	add(i.IconImageId())
-	sort.Strings(out)
+	add("/icon/file", i.IconImageId())
 	return out
 }
 

--- a/codec/anyblockjson/indexreferences.go
+++ b/codec/anyblockjson/indexreferences.go
@@ -1,0 +1,50 @@
+package anyblockjson
+
+import (
+	"fmt"
+
+	"github.com/anyproto/any-block/format/v1/model"
+)
+
+// IndexReferencesFromSnapshot retains provenance for metadata lifted into the
+// index. Call only for a snapshot accepted by the corresponding omission rule.
+func IndexReferencesFromSnapshot(sbType model.SmartBlockType, base *model.SmartBlockSnapshotBase, opts Options) []ObjectReference {
+	if base == nil {
+		return nil
+	}
+	id := base.GetDetails().GetFields()["id"].GetStringValue()
+	var idx Index
+	switch sbType {
+	case model.SmartBlockType_Workspace:
+		IndexFromSpaceSettings(&idx, base)
+		refs := idx.ObjectReferences(opts)
+		for n := range refs {
+			refs[n].ObjectID = id
+			switch refs[n].Path {
+			case "/homepage":
+				refs[n].SourcePath = "/properties/homepage"
+			case "/icon/file":
+				refs[n].SourcePath = "/properties/iconImage"
+			}
+		}
+		return refs
+	case model.SmartBlockType_Widget:
+		widgets, links, ok := widgetObjectWidgetsWithSources(base)
+		if !ok {
+			return nil
+		}
+		idx.Widgets = widgets
+		refs := idx.ObjectReferences(opts)
+		for n := range refs {
+			refs[n].ObjectID = id
+			for j, link := range links {
+				if refs[n].Path == fmt.Sprintf("/widgets/%d/target", j) {
+					refs[n].SourcePath = "/blocks/" + escapeSourcePathKey(link) + "/object_id"
+					break
+				}
+			}
+		}
+		return refs
+	}
+	return nil
+}

--- a/codec/anyblockjson/indexunresolved_test.go
+++ b/codec/anyblockjson/indexunresolved_test.go
@@ -146,3 +146,14 @@ func TestIndexReferencedObjectIds_TheSlotsThatNameAnObject(t *testing.T) {
 		ReferencedObjectIds(Options{ResolveProperties: newTypeIdVocabulary()})
 	assert.Equal(t, []string{"type-wine"}, folded)
 }
+
+func TestIndexObjectReferencesKeepEachLocation(t *testing.T) {
+	idx := &Index{Homepage: "same-target", Entrypoint: "same-target", Icon: &Icon{Format: "file", File: "same-target"},
+		Widgets: []Widget{{Target: "same-target"}, {Target: "_set"}, {Target: "same-target"}}, AutoWidgetTargets: []string{"ledger-only"}}
+	assert.Equal(t, []ObjectReference{
+		{TargetObjectID: "same-target", Path: "/entrypoint"}, {TargetObjectID: "same-target", Path: "/homepage"},
+		{TargetObjectID: "same-target", Path: "/widgets/0/target"}, {TargetObjectID: "same-target", Path: "/widgets/2/target"},
+		{TargetObjectID: "same-target", Path: "/icon/file"},
+	}, idx.ObjectReferences(Options{}))
+	assert.Equal(t, []string{"same-target"}, idx.ReferencedObjectIds(Options{}))
+}

--- a/codec/anyblockjson/missingref_test.go
+++ b/codec/anyblockjson/missingref_test.go
@@ -142,6 +142,8 @@ func TestMissingReference_SingularBlockSlots(t *testing.T) {
 			assert.NotContains(t, string(data), deadCid, "the dead id must not be written as if it existed")
 			require.Len(t, warnings, 1, "a rewrite destroys the stored id; the warning is its last appearance")
 			assert.Contains(t, warnings[0].Message, deadCid)
+			assert.Equal(t, IssueCodeUnresolvedTarget, warnings[0].Code)
+			assert.Equal(t, "/blocks/b1/object_id", warnings[0].Path)
 		})
 	}
 
@@ -245,6 +247,7 @@ func TestMissingReference_MentionTargets(t *testing.T) {
 		require.Len(t, warnings, 1)
 		assert.Contains(t, warnings[0].Message, deadCid)
 		// the snapshot is caller-owned: the rewrite must be copy-on-write
+		assert.Equal(t, "/blocks/b1/text/marks/0/param", warnings[0].Path)
 		assert.Equal(t, deadCid, snap.Blocks[1].GetText().Marks.Marks[0].Param,
 			"exportMarks mutated the caller's snapshot")
 	})
@@ -310,6 +313,7 @@ func TestMissingReference_MentionTargets(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, string(data), `<mention object_id=\"_missing_object\">Alice</mention>`)
 		require.Len(t, warnings, 1)
+		assert.Equal(t, "/blocks/r1-c1/text/marks/0/param", warnings[0].Path)
 	})
 }
 
@@ -339,6 +343,8 @@ func TestMissingReference_PropertyValueLists(t *testing.T) {
 		require.NoError(t, Validate(data, Options{}), "Marshal never emits what Validate rejects (I1)")
 		assert.Contains(t, compactDoc(data), `"related":["`+liveCid+`"]`)
 		require.Len(t, warnings, 1, "the real id warns; the sentinel — which carries nothing — drops silently")
+		assert.Equal(t, IssueCodeUnresolvedTarget, warnings[0].Code)
+		assert.Equal(t, "/properties/related/1", warnings[0].Path)
 		assert.Contains(t, warnings[0].Message, deadCid)
 	})
 
@@ -425,7 +431,7 @@ func TestMissingReference_PropertySettingsObjectTypes(t *testing.T) {
 		assert.Contains(t, compactDoc(data), `"object_types":["type-page","type-wine"]`)
 		require.Len(t, warnings, 1)
 		assert.Contains(t, warnings[0].Message, deadCid)
-		assert.Equal(t, "/property_settings/object_types", warnings[0].Path)
+		assert.Equal(t, "/properties/relationFormatObjectTypes/1", warnings[0].Path)
 	})
 
 	t.Run("a list emptied by the drop stays [], a cleared target set", func(t *testing.T) {
@@ -688,4 +694,29 @@ func TestMissingRef_ADeletedIconImageIsDropped(t *testing.T) {
 		assert.Contains(t, string(data), tombstoneCid,
 			"a failure to ask is not evidence of deletion")
 	})
+}
+
+func TestMissingReferencePathsUseStoredLocations(t *testing.T) {
+	var warnings []Issue
+	opts := missingRefOptions(&warnings)
+	opts.ResolveFormat = func(key domain.RelationKey) (model.RelationFormat, bool) {
+		return model.RelationFormat_object, key == "related/projects~"
+	}
+	link := func(id string) *model.Block {
+		return &model.Block{Id: id, Content: &model.BlockContentOfLink{Link: &model.BlockContentLink{TargetBlockId: deadCid}}}
+	}
+	snap := blockSnapshot(link("first/link~"), link("second-link"))
+	snap.Details.Fields["related/projects~"] = strList(liveCid, deadCid, deadCid)
+	_, err := Marshal(model.SmartBlockType_Page, snap, opts)
+	require.NoError(t, err)
+	var paths []string
+	for _, issue := range warnings {
+		if issue.Code == IssueCodeUnresolvedTarget {
+			paths = append(paths, issue.Path)
+		}
+	}
+	assert.ElementsMatch(t, []string{
+		"/blocks/first~1link~0/object_id", "/blocks/second-link/object_id",
+		"/properties/related~1projects~0/1", "/properties/related~1projects~0/2",
+	}, paths)
 }

--- a/codec/anyblockjson/refs.go
+++ b/codec/anyblockjson/refs.go
@@ -477,7 +477,7 @@ func (e *exporter) objectRef(id string) string {
 // fixpoint: the sentinel is kept as-is, so re-exports are byte-stable.
 func (e *exporter) singularObjectRef(path, slot, id string) string {
 	if missingFromSpace(e.opts, id) {
-		e.warn(path, "%s %q names no object in this space and is written as %q — "+
+		e.warnReference(path, "%s %q names no object in this space and is written as %q — "+
 			"the slot cannot say \"no target\" without deleting the block, and the sentinel "+
 			"keeps the fact that a reference existed", slot, id, missingObjectId)
 		return e.objectRef(missingObjectId)
@@ -500,7 +500,7 @@ func (e *exporter) droppedMissingListEntry(path, id string) bool {
 		return false
 	}
 	if id != missingObjectId {
-		e.warn(path, "%q names no object in this space and is dropped — "+
+		e.warnReference(path, "%q names no object in this space and is dropped — "+
 			"a list expresses absence by being shorter", id)
 	}
 	return true
@@ -536,7 +536,7 @@ func (e *exporter) exportMarks(path string, marks []*model.BlockContentTextMark)
 		switch m.Type {
 		case model.BlockContentTextMark_Mention:
 			if missingFromSpace(e.opts, m.Param) {
-				e.warn(path, "mention target %q names no object in this space and is written as %q — "+
+				e.warnReference(fmt.Sprintf("%s/text/marks/%d/param", path, i), "mention target %q names no object in this space and is written as %q — "+
 					"the mention's own text stays; only its address is gone", m.Param, missingObjectId)
 				replace(i, m, missingObjectId)
 				continue
@@ -690,9 +690,23 @@ func ValidateTypeExportMapping(opts Options, sbType model.SmartBlockType, id, in
 	if documentID == referenceID {
 		return nil
 	}
-	return fmt.Errorf("type document %q exports as %q, but references export as %q: "+
+	return &TypeIdentityMismatchError{ObjectID: id, InternalKey: internalKey, DocumentID: documentID, ReferenceID: referenceID}
+}
+
+// TypeIdentityMismatchError identifies a type whose document and references
+// would export under different identities. Callers can use errors.As through
+// export wrappers to report the affected object without parsing diagnostics.
+type TypeIdentityMismatchError struct {
+	ObjectID    string
+	InternalKey string
+	DocumentID  string
+	ReferenceID string
+}
+
+func (e *TypeIdentityMismatchError) Error() string {
+	return fmt.Sprintf("type document %q exports as %q, but references export as %q: "+
 		"ResolveProperties must provide a TypeResolver mapping this id to stored key %q (SPEC §9)",
-		id, documentID, referenceID, internalKey)
+		e.ObjectID, e.DocumentID, e.ReferenceID, e.InternalKey)
 }
 
 // reservedIdViolation states the derived-id reservation (§9) once, for the
@@ -872,4 +886,21 @@ func (imp *importer) envelopeId(ref string, sbType model.SmartBlockType) string 
 		return imp.opts.unfoldTypeRef(id)
 	}
 	return id
+}
+
+// warnReference records the source location before an absent target is rewritten
+// or dropped. Block paths use stored IDs, property paths use stored keys, and
+// list positions refer to the original snapshot. The caller supplies objectId.
+func (e *exporter) warnReference(path, format string, args ...any) {
+	if e.opts.OnWarning == nil {
+		return
+	}
+	if e.warningBlockID != "" && strings.HasPrefix(path, "/blocks/") {
+		path = "/blocks/" + escapeSourcePathKey(e.warningBlockID) + strings.TrimPrefix(path, "/blocks")
+	}
+	e.opts.OnWarning(Issue{Code: IssueCodeUnresolvedTarget, Path: path, Message: fmt.Sprintf(format, args...)})
+}
+
+func escapeSourcePathKey(key string) string {
+	return strings.NewReplacer("~", "~0", "/", "~1").Replace(key)
 }

--- a/codec/anyblockjson/relationformat.go
+++ b/codec/anyblockjson/relationformat.go
@@ -278,14 +278,14 @@ func (e *exporter) relationTargetKeys() []string {
 	entries := valueStringList(e.detail(detailKeyRelationFormatObjectTypes))
 	tr, _ := e.opts.ResolveProperties.(TypeResolver)
 	out := make([]string, 0, len(entries))
-	for _, entry := range entries {
+	for n, entry := range entries {
 		if tr != nil {
 			if key, ok := tr.TypeKeyById(entry); ok && key != "" {
 				out = append(out, key)
 				continue
 			}
 		}
-		if e.droppedMissingListEntry("/property_settings/object_types", entry) {
+		if e.droppedMissingListEntry(fmt.Sprintf("/properties/%s/%d", detailKeyRelationFormatObjectTypes, n), entry) {
 			continue
 		}
 		out = append(out, entry)

--- a/codec/anyblockjson/table.go
+++ b/codec/anyblockjson/table.go
@@ -275,7 +275,11 @@ func (e *exporter) cellToJSON(cell *model.Block) (any, error) {
 			e.visited[cell.Id] = true
 			// the shorthand renders without going through textToJSON, so it
 			// owes the same mention-target check (§8, §9)
-			md, err := renderInlineChecked(t.Text, e.exportMarks("/blocks", t.Marks.GetMarks()))
+			previousBlockID := e.warningBlockID
+			e.warningBlockID = cell.Id
+			marks := e.exportMarks("/blocks", t.Marks.GetMarks())
+			e.warningBlockID = previousBlockID
+			md, err := renderInlineChecked(t.Text, marks)
 			if err != nil {
 				return nil, fmt.Errorf("block %s: %w", cell.Id, err)
 			}

--- a/codec/anyblockjson/validate.go
+++ b/codec/anyblockjson/validate.go
@@ -80,6 +80,11 @@ const (
 type IssueCode string
 
 const (
+	// IssueCodeUnresolvedTarget identifies a reference to a missing object.
+	IssueCodeUnresolvedTarget IssueCode = "unresolved_target"
+	// IssueCodeTypeIdentityMismatch identifies an export rejected because a
+	// type document and its references would use different identities.
+	IssueCodeTypeIdentityMismatch IssueCode = "type_identity_mismatch"
 	// IssueCodeFileRemoteIgnored means the optional remote payload could not
 	// be understood. A bundle reader must still account for the file's bytes.
 	IssueCodeFileRemoteIgnored IssueCode = "file_remote_ignored"
@@ -97,7 +102,7 @@ const (
 
 // Issue is a single path-addressed validation problem or warning.
 type Issue struct {
-	Path    string // JSON pointer into the document, "" for the root
+	Path    string // document pointer, or source path for unresolved export references
 	Message string
 	Code    IssueCode // stable semantic meaning; Path and Message are presentation
 }

--- a/codec/anyblockjson/widgetobject.go
+++ b/codec/anyblockjson/widgetobject.go
@@ -152,15 +152,20 @@ func liftableWidgetTarget(stored string) bool {
 // cannot spell, or any block that is not the root, the header scaffolding,
 // or half of a pair.
 func widgetObjectWidgets(base *model.SmartBlockSnapshotBase) (widgets []Widget, ok bool) {
+	widgets, _, ok = widgetObjectWidgetsWithSources(base)
+	return
+}
+
+func widgetObjectWidgetsWithSources(base *model.SmartBlockSnapshotBase) (widgets []Widget, links []string, ok bool) {
 	blocks := base.GetBlocks()
 	if len(blocks) == 0 {
-		return nil, true
+		return nil, nil, true
 	}
 	byId := make(map[string]*model.Block, len(blocks))
 	isChild := map[string]bool{}
 	for _, b := range blocks {
 		if b == nil || b.Id == "" || byId[b.Id] != nil {
-			return nil, false
+			return nil, nil, false
 		}
 		byId[b.Id] = b
 		for _, c := range b.ChildrenIds {
@@ -173,24 +178,24 @@ func widgetObjectWidgets(base *model.SmartBlockSnapshotBase) (widgets []Widget, 
 			continue
 		}
 		if root != nil {
-			return nil, false // two roots: not the shape this rule measured
+			return nil, nil, false // two roots: not the shape this rule measured
 		}
 		root = b
 	}
 	if root == nil {
-		return nil, false // a cycle; nothing to walk
+		return nil, nil, false // a cycle; nothing to walk
 	}
 	if _, isRoot := root.Content.(*model.BlockContentOfSmartblock); !isRoot {
-		return nil, false
+		return nil, nil, false
 	}
 	if !plainBlock(root) {
-		return nil, false
+		return nil, nil, false
 	}
 	accounted := map[string]bool{root.Id: true}
 	for _, id := range root.ChildrenIds {
 		b := byId[id]
 		if b == nil {
-			return nil, false
+			return nil, nil, false
 		}
 		switch c := b.Content.(type) {
 		case *model.BlockContentOfLayout:
@@ -199,7 +204,7 @@ func widgetObjectWidgets(base *model.SmartBlockSnapshotBase) (widgets []Widget, 
 			// Export drops it from every document, so the omission loses
 			// nothing by accepting it — and accepts nothing more.
 			if c.Layout.GetStyle() != model.BlockContentLayout_Header || !plainBlock(b) {
-				return nil, false
+				return nil, nil, false
 			}
 			accounted[b.Id] = true
 			for _, cid := range b.ChildrenIds {
@@ -210,28 +215,29 @@ func widgetObjectWidgets(base *model.SmartBlockSnapshotBase) (widgets []Widget, 
 				// 11 of 11 in the corpus — and §7 drops the block, binding
 				// and all, so the binding is not content to fail closed on.
 				if t == nil || !emptyStructuralText(t) || len(t.ChildrenIds) > 0 {
-					return nil, false
+					return nil, nil, false
 				}
 				accounted[t.Id] = true
 			}
 		case *model.BlockContentOfWidget:
 			w, link, admitted := widgetPair(b, byId)
 			if !admitted {
-				return nil, false
+				return nil, nil, false
 			}
 			accounted[b.Id] = true
 			accounted[link] = true
 			widgets = append(widgets, w)
+			links = append(links, link)
 		default:
-			return nil, false
+			return nil, nil, false
 		}
 	}
 	for id := range byId {
 		if !accounted[id] {
-			return nil, false // unreachable from the root: real content, kept
+			return nil, nil, false // unreachable from the root: real content, kept
 		}
 	}
-	return widgets, true
+	return widgets, links, true
 }
 
 // widgetPair reads one wrapper-and-link pair into the flat index widget, or

--- a/format/v2/SPEC.md
+++ b/format/v2/SPEC.md
@@ -630,8 +630,8 @@ object**, whose `format` member says which kind it is:
   Exactly 200 production objects hold both an `iconName` and an `iconEmoji` —
   every one a bundled type mid-migration (`Space` 🌎/`folder` ×18, `Type`
   🥚/`extension-puzzle` ×12) — and `format` has already answered which one
-  wins, so the emoji is baggage rather than ambiguity. Export writes it with
-  a warning; a document that supplies it is not choosing an icon.
+  wins, so the emoji is baggage rather than ambiguity. Export preserves both
+  values without a warning; a document that supplies the emoji is not choosing an icon.
 
 **Precedence, when the store holds more than one source:** `iconName` →
 `iconEmoji` → `iconImage`. That is `core/api/service/icon.go`'s rule, the
@@ -7217,14 +7217,18 @@ type Legend struct {
 // Path and Message are presentation: they are free to improve. Code is the
 // stable semantic discriminator, and the only member a caller may branch on.
 // Most issues are presentation-only and leave it empty.
+// unresolved_target export paths address the original snapshot: /blocks/<id>/object_id,
+// /blocks/<id>/text/marks/<index>/param, or /properties/<stored-key>/<index>.
+// IDs and keys use JSON Pointer escaping; indices precede any export-time drops.
+// The export caller prefixes its source object ID for a self-contained report path.
 type Issue struct {
-    Path    string // JSON pointer into the document, "" for the root
+    Path    string // document pointer, or source path for unresolved export references
     Message string
     Code    IssueCode
 }
 
-// IssueCode names an Issue's semantic meaning. Two codes exist, one per
-// derived-id namespace (§9, §11): a reader wired without a SpaceId leaves
+// IssueCode names an Issue's semantic meaning. The two import codes below
+// cover the derived-id namespaces (§9, §11): a reader without a SpaceId leaves
 // this document's folded participant identities bare, addressing no object,
 // and a reader that DOES name a space but carries no TypeResolver leaves its
 // `type-<internal_key>` references folded, addressing no object in that
@@ -7237,6 +7241,8 @@ type IssueCode string
 const (
     IssueCodeFoldedParticipantsWithoutSpace IssueCode = "folded_participants_without_space"
     IssueCodeFoldedTypesWithoutResolver     IssueCode = "folded_types_without_resolver"
+    IssueCodeTypeIdentityMismatch           IssueCode = "type_identity_mismatch"
+    IssueCodeUnresolvedTarget               IssueCode = "unresolved_target"
 )
 
 type Options struct {
@@ -7443,7 +7449,13 @@ document inside it. The bundle path plan never reaches that branch:
 func ValidateTypeExportMapping(opts Options, sbType model.SmartBlockType, id, internalKey string) error
 ```
 
-checks the other half of that agreement: a type document's stored id must
+A mismatch returns `*TypeIdentityMismatchError`, with `ObjectID`,
+`InternalKey`, `DocumentID`, and `ReferenceID` fields. It remains discoverable
+with `errors.As` through export wrappers. Integrations report it with
+`IssueCodeTypeIdentityMismatch` and the affected `ObjectID`; `Error()` is a
+technical diagnostic, not user-facing copy.
+
+The check verifies the other half of that agreement: a type document's stored id must
 export to the same id in references as on its envelope. `Marshal`,
 `bundle.BuildPlan`, and `Composer.ObserveWritten` run this check and refuse
 missing or conflicting type mappings. `FoldDocumentId` remains the pure


### PR DESCRIPTION
Unresolved export references previously pointed only to `/blocks` or `index.json`, making the source hard to locate. Preserve stored block IDs, property keys, original list positions, and source objects for references lifted into the index. Repeated targets retain their individual locations, while the bundle's unresolved-target inventory remains unique. Integrations can construct paths such as `<object-id>/blocks/<block-id>/object_id`.

Also return typed type-identity mismatch errors, distinguish relation-option description notes from extra-content warnings, and stop warning when both named and emoji icons are preserved. Missing option identity and other reconstruction failures retain their existing diagnostic category.

Document the integration behavior and the known raw-CID icon limitation in one-to-one spaces. Heart consumes the new diagnostics and controls report severity, completion status, and suppression of routine built-in property notes; those application changes are separate.

Validation: `go test ./...` passed. Regression coverage includes repeated references, source-path escaping, table-cell mentions, homepage/icon/widget provenance, wrapped type errors, and option-only classification.
